### PR TITLE
Add Core Ultra compatibility: engine-key resolver, optional RC6 fallback, and robust JSON streaming for intel_gpu_top    

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,19 @@ igpu_power_package 5.480595
 # TYPE igpu_rc6 gauge
 igpu_rc6 99.999993
 ```
+
+
+## Compatibility & Fallback
+
+- Engine key compatibility: supports both legacy (e.g. `Video/0`) and new (`Video`) keys.
+- JSON parsing: robust stream parser for `intel_gpu_top -J`.
+- Optional fallback (off by default):
+  - `FALLBACK_FROM_RC6=1` enables deriving non-idle percent as `100 - rc6` when engine busy reports 0.
+  - `FALLBACK_TARGETS=Video` (default) or comma-separated list: `Video,Render/3D,Blitter,VideoEnhance`.
+
+Example:
+
+```bash
+REFRESH_PERIOD_MS=200 FALLBACK_FROM_RC6=1 FALLBACK_TARGETS=Video \
+  python3 intel-gpu-exporter.py
+```


### PR DESCRIPTION
Summary: Fixes zero iGPU utilization on Intel Core Ultra by handling intel_gpu_top -J schema differences and adds an optional RC6-derived fallback while preserving backward
compatibility for existing systems.
-
Key changes:
    - Engine-key compatibility: Resolves metrics for names with and without “/0” (e.g., Render/3D/0 vs Render/3D, Video/0 vs Video, etc.).
    - Optional RC6 fallback: When engine busy values are absent/zero on certain platforms, derive “active percent” from RC6 (disabled by default).
    - Robust streaming parser: Bracket-depth JSON framing to consume intel_gpu_top -J reliably under varying flush patterns.
    - Device ID parsing: More tolerant regex (supports device=…, device0=…, and pci:vendor=…,device=…).
    - Configurables:
    - `REFRESH_PERIOD_MS` (default 1000) to tune sampling.
    - `FALLBACK_FROM_RC6` (`0` default) to enable RC6-based fallback.
    - `FALLBACK_TARGETS` (default `Video`) to choose which engines get fallback.
- Container updates:
    - Dockerfile based on `python:3.12-slim`, installs `intel-gpu-tools` and `catatonit`.
    - Entrypoint uses `catatonit`; exposes port `8080`.
    - Run requirements: `--privileged` and mount `/dev/dri:/dev/dri:rw`.

- Backward compatibility:
    - Metric names unchanged (igpu_*), existing dashboards continue to work.
    - RC6 fallback is opt-in; default behavior matches current exporter.
    - No changes to default port or paths.
    - No changes to default port or paths.
-
Why this is needed:
    - Core Ultra/Xe platforms sometimes emit engine keys without the “/0” suffix and can report zero engine busy while RC6 reflects activity. This PR normalizes keys and
optionally uses RC6 for a reasonable utilization approximation when engine busy fields are missing.
-
Testing:
    - Verified on Core Ultra (e.g., Intel 125H): non-zero utilization recovered with resolver, RC6 fallback optional.
    - Verified on prior-gen Intel (e.g., 13th-gen): continues to report correctly with fallback disabled.
-
Usage examples:
    - Standard run:
    - `docker run -d --name intel-gpu-exporter --privileged -v /dev/dri:/dev/dri:rw -p 8080:8080 ghcr.io/bjia56/intel-gpu-exporter:tag`
- With RC6 fallback and faster sampling (optional):
    - `docker run -d --name intel-gpu-exporter --privileged -v /dev/dri:/dev/dri:rw -e REFRESH_PERIOD_MS=200 -e FALLBACK_FROM_RC6=1 -e FALLBACK_TARGETS=Video -p 8080:8080
ghcr.io/bjia56/intel-gpu-exporter:tag`

- Notes:
    - Keeps CPU/memory overhead minimal.
    - No dependency changes beyond prometheus_client and intel-gpu-tools in the container.
    - No dependency changes beyond prometheus_client and intel-gpu-tools in the container.
-
Checklist:
    - Preserves existing metrics and default behavior
    - Adds opt-in fallback for affected platforms
    - Container build and run instructions included
    - Tested on mixed-architecture hosts